### PR TITLE
Automated Workflow Fix: Fix workflow failure: The Maven build is configured to compile with Java 21 (via the `--release 21` flag set by the maven‑compiler‑plugin), but the workflow installs only Java 17. This causes the compiler to reject the release flag, leading to a build failure.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 


### PR DESCRIPTION
This PR contains an automated fix for a failed GitHub Actions workflow.