### PR TITLE
Automated Workflow Fix: Fix workflow failure: The Maven compiler plugin is configured to compile with Java 21 (release 21), but the workflow installs and uses Java 17. The JDK 17 does not support compiling for release 21, causing the build to fail.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 


### PR DESCRIPTION
This PR contains an automated fix for a failed GitHub Actions workflow.