### PR TITLE
Automated Workflow Fix: Fix workflow failure: The Maven project is configured to compile with Java release 21, but the GitHub Actions runner is using Java 17 (Temurin JDK 17.0.16). The Maven compiler plugin therefore fails with "release version 21 not supported".

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: Setup JDK 21
+      - name: Setup JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 17
           distribution: 'temurin'
           cache: maven
 


### PR DESCRIPTION
This PR contains an automated fix for a failed GitHub Actions workflow.