### PR TITLE
Fix workflow failure: The Maven compiler is configured to compile wit…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
           cache: maven
 
       - name: Build with Maven
-        run: mvn clean package -DskipTests=false
+        run: mvn clean package -DskipTests=false -Dmaven.compiler.release=17
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
…h Java release 21, but the workflow installs JDK 17, which does not support that release level. This mismatch causes the compiler to fail with "release version 21 not supported".